### PR TITLE
Feature/populate appointment blocks

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -23,7 +23,6 @@ class ExternalModule extends AbstractExternalModule {
      * @inheritdoc.
      */
     function redcap_every_page_top($project_id) {
-
     }
 
     /**
@@ -46,14 +45,12 @@ class ExternalModule extends AbstractExternalModule {
             $data = $test_site->getData();
             $project_id = $data['project_id'];
             $minute_interval = $data['site_appointment_duration'];
-            //$open_time = "'" . $data['open_time'] . "'";
             $open_time = $data['open_time'];
             $close_time = ($data['close_time'] !== '00:00') ? $data['close_time'] : '23:59';
-            //$close_time = "'$close_time'";
             $horizon_days = $data['horizon_days'];
             $closed_days = $data['closed_days'];
             $mults_needed = $horizon_days*(60/$minute_interval)*24;
-            $site_id = 1;
+            $site_id = $test_site->getId();
             //$closed_days_line = (isset($closed_days)) ? "AND weekday(date) NOT IN (" . $closed_days . ")" : '';
 
             $sql = "

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -25,6 +25,25 @@ class ExternalModule extends AbstractExternalModule {
     function redcap_every_page_top($project_id) {
     }
 
+    function redcap_save_record($project_id, $record, $instrument, $event_id, $group_id, $survey_hash, $response_id, $repeat_instance) {
+        $appointment_form = $this->getProjectSetting('appointment_form');
+        if ( $this->framework->isSurveyPage() && $instrument = $appointment_form) {
+            $get_data = [
+                'project_id' => $project_id,
+                'records' => [$record],
+                'events' => [$event_id]
+            ];
+            $redcap_data = \REDCap::getData($get_data);
+            $appointment_id = $redcap_data[$record][$event_id][$appointment_form];
+            $factory = new EntityFactory();
+            $Appointment = $factory->getInstance('fr_appointment', $appointment_id);
+            $Appointment->setData(['record_id' => $record]);
+            $Appointment->save();
+
+            //\REDCap::saveData(); // split relevant data out to @SURVEY-HIDDEN fields
+        }
+    }
+
     /**
      * @inheritdoc.
      */

--- a/classes/entity/list/TestSiteList.php
+++ b/classes/entity/list/TestSiteList.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace FRCOVID\Entity;
+
+use FRCOVID\ExternalModule\ExternalModule;
+use RCView;
+use REDCapEntity\EntityList;
+use REDCapEntity\StatusMessageQueue;
+
+require_once dirname(__DIR__) . '/PermissionChecker.php';
+
+class TestSiteList extends EntityList {
+
+    protected function renderPageBody() {
+
+        if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+            if (isset($_POST['create_all_future_appointment_blocks'])) {
+                $this->module->createAllFutureAppointmentBlocks();
+                StatusMessageQueue::enqueue('Created future appointment blocks.');
+            }
+        }
+
+        parent::renderPageBody();
+    }
+
+    protected function renderAddButton() {
+
+        $btn = RCView::i(['class' => 'fas fa-calendar-alt']);
+        $btn = RCView::button([
+            'type' => 'submit',
+            'name' => 'create_all_future_appointment_blocks',
+            'class' => 'btn btn-primary',
+        ], $btn . ' Generate future appointments for <b>all</b> sites');
+
+        echo RCView::form(['id' => 'generate_all_appointment_blocks', 'method' => 'post'], $btn);
+        parent::renderAddButton();
+    }
+}

--- a/classes/entity/list/TestSiteList.php
+++ b/classes/entity/list/TestSiteList.php
@@ -7,8 +7,6 @@ use RCView;
 use REDCapEntity\EntityList;
 use REDCapEntity\StatusMessageQueue;
 
-require_once dirname(__DIR__) . '/PermissionChecker.php';
-
 class TestSiteList extends EntityList {
 
     protected function renderPageBody() {

--- a/config.json
+++ b/config.json
@@ -5,7 +5,8 @@
     "permissions": [
         "redcap_every_page_top",
         "redcap_module_system_enable",
-        "redcap_module_system_disable"
+        "redcap_module_system_disable",
+        "redcap_save_record"
     ],
     "framework-version": 3,
     "authors": [
@@ -30,9 +31,9 @@
     },
     "project-settings": [
         {
-            "key": "appointment_horizon",
-            "name": "How many days of appointments do you want to be available to the study respondents at all times? These appointment blocks will be automatically generated nightly",
-            "type": "text",
+            "key": "appointment_form",
+            "name": "Which instrument is used for appointments?",
+            "type": "form-list",
             "required": true
         }
     ],
@@ -42,7 +43,7 @@
         "project": [
             {
                 "name": "Define Sites",
-                "icon": "fas fa-cloud-download-alt",
+                "icon": "fas fa-clinic-medical",
                 "url": "plugins/site_entry.php"
             }
         ]

--- a/config.json
+++ b/config.json
@@ -48,5 +48,12 @@
         ]
     },
     "crons": [
+        {
+            "cron_name": "create_all_future_appointment_blocks",
+            "cron_description": "Create appointment blocks until horizon",
+            "method": "createAllFutureAppointmentBlocks",
+            "cron_frequency": "86400",
+            "cron_max_run_time": "360"
+        }
     ]
 }

--- a/plugins/site_entry.php
+++ b/plugins/site_entry.php
@@ -1,5 +1,11 @@
 <?php
 
-$view = new \REDCapEntity\EntityList('test_site', $module);
+require_once dirname(__DIR__) . '/classes/entity/list/TestSiteList.php';
+
+use FRCOVID\Entity\TestSiteList;
+
+$view = new TestSiteList('test_site', $module);
 $view->setOperations(['create', 'update', 'delete'])
-    ->render('project', 'Title');
+    // TODO: Create an extended Entity object at classes/entity/TestSite.php
+    //->setBulkOperation('create_future_appointments', 'Manually generate new appointments', 'Generated new appointments for each site', 'green')
+    ->render('project');


### PR DESCRIPTION
Creates project level interface for making test sites with:
- A full name
- An abbreviated name
- An address
- \* An Appointment duration
- \* Hours of operation (open and close times)
- \* An optional _single_ day that the test site is closed
- \* How many days of appointments to make available

Options marked with \* are used in the automated creation of appointment blocks via a cron job. The interface for entering test sites also allows manual creation of appointment dates using the same function.

Parameters MUST be entered correctly before creating appointments as there is currently no interface for interacting with appointment blocks!