### PR TITLE
add location id to research_encounter_id

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -115,21 +115,23 @@ class ExternalModule extends AbstractExternalModule {
         return [$Appointment_data, $Site];
     }
 
-    function encodeUnique($record_id, $instance_id, $record_pad = 7, $instance_pad = 2) {
+    function encodeUnique($record_id, $instance_id, $record_pad = 5, $instance_pad = 2) {
         /* converts record id and instance id into hex,
          * creates a checksum
          * concats all
-         * 16 characters total
-         * <record>-<instance>-checksum
-         * 2 characters for human readability ('--')
-         * 7 characters for record; 16^7 = > 268 million records
+         * 11 characters total
+         * <location_id>-<record>-<instance>-checksum
+         * 3 characters for human readability ('---')
+         * 1 character for location ID
+         * 5 characters for record; 16^5 = > 1 million records
          * 2 characters for instance; 16^2 = 256 visits per person
          * 1 character for checksum
          */
+        $location_encode = dechex($this->getProjectSetting('location_id'));
         $record_encode = str_pad(dechex($record_id), $record_pad, '0', STR_PAD_LEFT);
         $visit_encode = str_pad(dechex($instance_id), $instance_pad, '0', STR_PAD_LEFT);
         $check_digit = $this->generateLuhnChecksum($record_encode . $visit_encode);
-        return strtoupper($record_encode . '-' . $visit_encode . '-' . $check_digit);
+        return strtoupper($location_encode . '-' . $record_encode . '-' . $visit_encode . '-' . $check_digit);
     }
 
     function generateLuhnChecksum($input) {

--- a/config.json
+++ b/config.json
@@ -31,6 +31,12 @@
     },
     "project-settings": [
         {
+            "key": "location_id",
+            "name": "Which location ID is this project for? (0-15)",
+            "type": "text",
+            "required": true
+        },
+        {
             "key": "appointment_form",
             "name": "Which instrument is used for appointments?",
             "type": "form-list",


### PR DESCRIPTION
(not used in checksum at this moment)

New format is:
`<location_id>-<record_id>-<visit_id>-<checksum>`

Adds capacity for 16 locations numbered 0-15, set in the project level settings.

~~Note that [the R codes for verification and generation](https://gist.github.com/ChemiKyle/bd2743f002fcd170521cab8ea3e7e1b6) do not consider this update at the moment.~~ Now they only support this update.