### PR TITLE
Feature/add start date field to test site

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -184,6 +184,7 @@ class ExternalModule extends AbstractExternalModule {
         $closed_days_line = (isset($closed_days)) ? "AND weekday(date) NOT IN (" . $closed_days . ")" : '';
         $start_date = $data['start_date'];
 
+        // If the start_date is in the past or not set, use today's date
         $start_date = (!empty($start_date) && $start_date > time()) ? strftime('%Y-%m-%d', $start_date) : date('Y-m-d');
 
         $sql = "
@@ -222,10 +223,6 @@ SELECT unix_timestamp(), unix_timestamp(), $site_id, FLOOR(UNIX_TIMESTAMP(date))
             ";
 
         $result = $this->framework->query($sql);
-    }
-
-    function redcap_module_system_disable($version) {
-        EntityDB::dropSchema($this->PREFIX);
     }
 
     function redcap_entity_types() {

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -179,7 +179,7 @@ class ExternalModule extends AbstractExternalModule {
         $close_time = ($data['close_time'] !== '00:00') ? $data['close_time'] : '23:59';
         $horizon_days = $data['horizon_days'];
         $closed_days = $data['closed_days'];
-        $mults_needed = $horizon_days*(60/$minute_interval)*24;
+        $mults_needed = (1 + $horizon_days)*(60/$minute_interval)*24;
         $site_id = $test_site->getId();
         $closed_days_line = (isset($closed_days)) ? "AND weekday(date) NOT IN (" . $closed_days . ")" : '';
         $start_date = $data['start_date'];
@@ -191,7 +191,7 @@ class ExternalModule extends AbstractExternalModule {
 INSERT INTO redcap_entity_fr_appointment (created, updated, site, appointment_block, project_id)
 SELECT unix_timestamp(), unix_timestamp(), $site_id, FLOOR(UNIX_TIMESTAMP(date)), $project_id
             FROM (
-                SELECT (DATE('$start_date') + 1 + INTERVAL c.number*$minute_interval MINUTE) AS date
+                SELECT (DATE('$start_date') + INTERVAL c.number*$minute_interval MINUTE) AS date
                     FROM (SELECT singles + tens + hundreds number FROM 
                         ( SELECT 0 singles
                             UNION ALL SELECT   1 UNION ALL SELECT   2 UNION ALL SELECT   3


### PR DESCRIPTION
Adds the ability to set the first day of available appointments to each test site; once that date has passed, appointments will be generated from the date at which the function is run. Setting future days to ~0~ -1 will prevent any appointments being allowed to be made. This field appears as free text but should be entered as `MM/DD/YYYY` or `YYYY/MM/DD`.

Also removed the "feature" where entity destroys its tables on module disable. Updating this module, disabling and re-enabling it does not appear to create the additional column on the backend, however; this update applied to a live system should be accompanied by the following SQL being run on the REDCap server:
```sql
ALTER TABLE redcap_entity_test_site
	ADD start_date INT NULL
```

I am tired and might be forgetting something, will write better documentation tomorrow.