### PR TITLE
add hardcoded scraping of alert emails into a comments field

### DIFF
--- a/config.json
+++ b/config.json
@@ -67,6 +67,11 @@
                 "name": "Define Sites",
                 "icon": "fas fa-clinic-medical",
                 "url": "plugins/site_entry.php"
+            },
+            {
+                "name": "Appointment Blocks",
+                "icon": "fas fa-clinic-medical",
+                "url": "plugins/appointment_blocks.php"
             }
         ]
     },
@@ -76,6 +81,13 @@
             "cron_description": "Create appointment blocks until horizon",
             "method": "createAllFutureAppointmentBlocks",
             "cron_frequency": "86400",
+            "cron_max_run_time": "360"
+        },
+        {
+            "cron_name": "pipe_email_alert_times_into_comments",
+            "cron_description": "Scrapes email alert notification times into a comments field",
+            "method": "addEmailAlertsToAllProjectComments",
+            "cron_frequency": "60",
             "cron_max_run_time": "360"
         }
     ]

--- a/config.json
+++ b/config.json
@@ -67,11 +67,6 @@
                 "name": "Define Sites",
                 "icon": "fas fa-clinic-medical",
                 "url": "plugins/site_entry.php"
-            },
-            {
-                "name": "Appointment Blocks",
-                "icon": "fas fa-clinic-medical",
-                "url": "plugins/appointment_blocks.php"
             }
         ]
     },


### PR DESCRIPTION
Checks `redcap_alerts` for email alerts sent out on negative test results for a given project with the `alert_title` = 'Negative result swab'. If there are no contents in the field `result_comments` in the same event that triggered the email alert, then "Negative alert email sent: <timestamp>" will be put in the field `result_comments`
