### PR TITLE
use JSON to create a custom daily schedule

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -187,6 +187,10 @@ class ExternalModule extends AbstractExternalModule {
                 'path' => 'classes/entity/TestSite.php',
                 'name' => 'FRCOVID\Entity\TestSite'
             ],
+            'form_class' => [
+                'path' => 'classes/entity/form/TestSiteForm.php',
+                'name' => 'FRCOVID\Entity\TestSiteForm'
+            ],
             'properties' => [
                 'site_long_name' => [
                     'name' => 'Testing Site Full Name',
@@ -237,6 +241,20 @@ class ExternalModule extends AbstractExternalModule {
                 'testing_type' => [
                     'name' => 'Type of testing done at this site',
                     'type' => 'text',
+                ],
+                'use_custom_daily_schedule' => [
+                    // Single day only supported until Entity gets update for multiselect
+                    'name' => 'Use custom daily schedule',
+                    'type' => 'text',
+                    'default' => '0',
+                    'choices' => [
+                        '0' => 'No',
+                        '1' => 'Yes',
+                    ]
+                ],
+                'custom_daily_schedule' => [
+                    'name' => 'Custom week',
+                    'type' => 'json',
                 ],
                 'project_id' => [
                     'name' => 'Project ID',

--- a/classes/entity/TestSite.php
+++ b/classes/entity/TestSite.php
@@ -51,7 +51,7 @@ class TestSite extends Entity {
                 $custom_days_sql .= "(
                             WEEKDAY(date) = $dow
                             AND
-                            TIME(date) between TIME('$open') AND TIME('$close')
+                            TIME(date) between TIME('$open') AND TIME('$close') - INTERVAL 1 SECOND
                         )";
                 if ($day !== "Sunday") {
                     $custom_days_sql .= " OR ";

--- a/classes/entity/TestSite.php
+++ b/classes/entity/TestSite.php
@@ -41,21 +41,29 @@ class TestSite extends Entity {
             // mapping of weekday name to integer in MySQL spec
             $dow_map = array('Monday' => 0, 'Tuesday' => 1, 'Wednesday' => 2, 'Thursday' => 3, 'Friday' => 4, 'Saturday' => 5, 'Sunday' => 6);
             $custom_daily = json_decode(json_encode($data['custom_daily_schedule']), True); // stored in DB as nested stdClass objects
-            $custom_days_sql = "";
+            $custom_days_sql = " AND (
+            ";
             foreach($custom_daily as $day => $hours) {
-                $dow_encoding = $dow_map[$day];
+                $dow = $dow_map[$day];
                 $open = $hours['open'];
                 $close = $hours['close'];
                 // TODO: finish and integrate
-                $custom_days_sql .= "OR (
-                            WEEKDAY(date) = $day
+                $custom_days_sql .= "(
+                            WEEKDAY(date) = $dow
                             AND
                             TIME(date) between TIME('$open') AND TIME('$close')
                         )";
+                if ($day !== "Sunday") {
+                    $custom_days_sql .= " OR ";
+                }
             }
-            return;
+            $custom_days_sql .= ")";
+            $days_sql = $custom_days_sql;
         } else {
+        $days_sql = $closed_days_line . "
+            AND TIME(date) between TIME('$open_time') and TIME('$close_time') - INTERVAL 1 SECOND";
         }
+
 
         $sql = "
 INSERT INTO redcap_entity_fr_appointment (created, updated, site, appointment_block, project_id)
@@ -82,8 +90,7 @@ SELECT unix_timestamp(), unix_timestamp(), $site_id, FLOOR(UNIX_TIMESTAMP(date))
                 WHERE c.number BETWEEN 0 AND $mults_needed
             ) dates
             WHERE date between DATE('$start_date') and CAST( (DATE('$start_date') + INTERVAL (1 + $horizon_days) DAY) AS DATETIME ) " .
-            $closed_days_line . "
-            AND TIME(date) between TIME('$open_time') and TIME('$close_time') - INTERVAL 1 SECOND
+            $days_sql . "
                 -- do not create duplicate appointment times at any site
                 AND NOT EXISTS (
                     SELECT * FROM redcap_entity_fr_appointment WHERE

--- a/classes/entity/form/TestSiteForm.php
+++ b/classes/entity/form/TestSiteForm.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace FRCOVID\Entity;
+
+use FRCOVID\ExternalModule\ExternalModule;
+use RCView;
+use REDCapEntity\EntityForm;
+use REDCapEntity\StatusMessageQueue;
+
+class TestSiteForm extends EntityForm {
+    protected $module;
+
+    protected function renderPageBody() {
+
+        $module = $this->entity->getModule();
+
+        $this->jsFiles[] = $module->framework->getUrl('js/site_form.js');
+        $this->cssFiles[] = $module->framework->getUrl('css/site_form.css');
+
+        parent::renderPageBody();
+
+        echo RCView::button([
+                'type' => 'button',
+                'name' => 'prettify_json',
+                'class' => 'btn btn-primary btn-sm',
+                'onclick' => 'prettyPrint()',
+                ], 'Pretty format JSON'
+        );
+    }
+
+    protected function renderAddButton() {
+
+        $btn = RCView::i(['class' => 'fas fa-sync']);
+        $btn = RCView::button([
+            'type' => 'button',
+            'name' => 'prettify_json',
+            'class' => 'btn btn-primary btn-sm',
+        ], $btn . ' Refresh OnCore Staff List');
+
+        echo RCView::form(['onclick' => 'prettyPrint()'], $btn);
+    }
+
+}

--- a/classes/entity/form/TestSiteForm.php
+++ b/classes/entity/form/TestSiteForm.php
@@ -24,7 +24,7 @@ class TestSiteForm extends EntityForm {
                 'name' => 'prettify_json',
                 'class' => 'btn btn-primary btn-sm',
                 'onclick' => 'prettyPrint()',
-                ], 'Pretty format JSON'
+                ], 'Check and format JSON'
         );
     }
 

--- a/css/site_form.css
+++ b/css/site_form.css
@@ -1,0 +1,5 @@
+#redcap-entity-prop-custom_daily_schedule {
+    resize: both;
+    overflow: auto;
+    width: 25%;
+}

--- a/js/site_form.js
+++ b/js/site_form.js
@@ -5,8 +5,14 @@ $(function() {
 function prettyPrint() {
     let $field = $('#redcap-entity-prop-custom_daily_schedule');
     let ugly = $field.val();
-    let pretty = JSON.stringify(JSON.parse(ugly), undefined, 2);
-    $field.val(pretty);
+    try {
+        let pretty = JSON.stringify(JSON.parse(ugly), undefined, 2);
+        $field.val(pretty);
+    } catch (err) {
+        if (err instanceof SyntaxError) {
+            alert("There is an error in your JSON syntax:\n" + err.message);
+        }
+    }
 }
 
 /*

--- a/js/site_form.js
+++ b/js/site_form.js
@@ -15,15 +15,6 @@ function prettyPrint() {
     }
 }
 
-/*
-function prettyPrint() {
-    // jQuery version doesn't work
-    let ugly = document.getElementById('redcap-entity-prop-custom_daily_schedule').value;
-    let pretty = JSON.stringify(JSON.parse(ugly), undefined, 2);
-    document.getElementById('redcap-entity-prop-custom_daily_schedule').value = pretty;
-}
-*/
-
 function fillIfBlank() {
     let $field = $("#redcap-entity-prop-custom_daily_schedule");
     if ( !$field.val() ) {

--- a/js/site_form.js
+++ b/js/site_form.js
@@ -1,0 +1,62 @@
+$(function() {
+    fillIfBlank();
+});
+
+function prettyPrint() {
+    let $field = $('#redcap-entity-prop-custom_daily_schedule');
+    let ugly = $field.val();
+    let pretty = JSON.stringify(JSON.parse(ugly), undefined, 2);
+    $field.val(pretty);
+}
+
+/*
+function prettyPrint() {
+    // jQuery version doesn't work
+    let ugly = document.getElementById('redcap-entity-prop-custom_daily_schedule').value;
+    let pretty = JSON.stringify(JSON.parse(ugly), undefined, 2);
+    document.getElementById('redcap-entity-prop-custom_daily_schedule').value = pretty;
+}
+*/
+
+function fillIfBlank() {
+    let $field = $("#redcap-entity-prop-custom_daily_schedule");
+    if ( !$field.val() ) {
+        fillDefault();
+    }
+}
+
+function fillDefault() {
+    let $field = $("#redcap-entity-prop-custom_daily_schedule");
+    $field.val(JSON.stringify(default_days, undefined, 2));
+}
+
+default_days = {
+    "Monday": {
+        "open": "",
+        "close": ""
+    },
+    "Tuesday": {
+        "open": "",
+        "close": ""
+    },
+    "Wednesday": {
+        "open": "",
+        "close": ""
+    },
+    "Thursday": {
+        "open": "",
+        "close": ""
+    },
+    "Friday": {
+        "open": "",
+        "close": ""
+    },
+    "Saturday": {
+        "open": "",
+        "close": ""
+    },
+    "Sunday": {
+        "open": "",
+        "close": ""
+    }
+}


### PR DESCRIPTION
Requires an update to the SQL db

```sql
ALTER TABLE redcap_entity_test_site
	ADD custom_daily_schedule TEXT NULL,
    ADD use_custom_daily_schedule VARCHAR(255) NULL
```

Introduces a JSON field while defining or editing a site and a toggle to use it or not for site generation. You may set open and close times for each day of the week in the JSON.  
If there is not data in the JSON field, a template will be inserted for you.

Allows formatting and syntax checking of the JSON field via the "Check and format JSON" button below the "Custom week" field.