### PR TITLE
Feature/embed available appt table in survey

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -13,7 +13,13 @@ use REDCapEntity\StatusMessageQueue;
 
 class ExternalModule extends AbstractExternalModule {
 
-    function redcap_every_page_top($project_id) {
+    function redcap_survey_page_top($project_id, $record = NULL, $instrument, $event_id, $group_id = NULL, $survey_hash, $response_id = NULL, $repeat_instance = 1 ) {
+        $appointment_form = $this->framework->getProjectSetting('appointment_form');
+        if ($instrument == $appointment_form) {
+            $this->setJsSettings(['data_endpoint' => $this->framework->getProjectSetting('data_endpoint')]);
+            $this->includeJs('js/populate_appointment_table.js');
+            $this->includeCss('css/appointment_table.css');
+        }
     }
 
     function redcap_save_record($project_id, $record, $instrument, $event_id, $group_id, $survey_hash, $response_id, $repeat_instance) {
@@ -281,6 +287,10 @@ class ExternalModule extends AbstractExternalModule {
         ];
 
         return $types;
+    }
+
+    protected function includeCss($path) {
+        echo '<link rel="stylesheet" href="' . $this->getUrl($path) . '">';
     }
 
     /**

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -13,9 +13,10 @@ use REDCapEntity\StatusMessageQueue;
 
 class ExternalModule extends AbstractExternalModule {
 
-    function redcap_survey_page_top($project_id, $record = NULL, $instrument, $event_id, $group_id = NULL, $survey_hash, $response_id = NULL, $repeat_instance = 1 ) {
-        $appointment_form = $this->framework->getProjectSetting('appointment_form');
-        if ($instrument == $appointment_form) {
+
+    function redcap_every_page_top($project_id) {
+        // inject JS for appointment table population
+        if ($project_id) {
             $this->setJsSettings(['data_endpoint' => $this->framework->getProjectSetting('data_endpoint')]);
             $this->includeJs('js/populate_appointment_table.js');
             $this->includeCss('css/appointment_table.css');

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
     "namespace": "FRCOVID\\ExternalModule",
     "description": "Facilitate the scheduling and data management of COVID-19 testing for first responders. See the complete documentation at <a href='https://github.com/ctsit/fr_covidata'>https://github.com/ctsit/fr_covidata</a>",
     "permissions": [
-        "redcap_every_page_top",
+        "redcap_survey_page_top",
         "redcap_module_system_enable",
         "redcap_module_system_disable",
         "redcap_save_record"
@@ -41,6 +41,11 @@
             "name": "Which instrument is used for appointments?",
             "type": "form-list",
             "required": true
+        },
+        {
+            "key": "data_endpoint",
+            "name": "REDCap Webservices url for appointment data: ",
+            "type": "text"
         },
         {
             "key": "repeat_implement",

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
     "namespace": "FRCOVID\\ExternalModule",
     "description": "Facilitate the scheduling and data management of COVID-19 testing for first responders. See the complete documentation at <a href='https://github.com/ctsit/fr_covidata'>https://github.com/ctsit/fr_covidata</a>",
     "permissions": [
-        "redcap_survey_page_top",
+        "redcap_every_page_top",
         "redcap_module_system_enable",
         "redcap_module_system_disable",
         "redcap_save_record"

--- a/config.json
+++ b/config.json
@@ -44,7 +44,7 @@
         },
         {
             "key": "data_endpoint",
-            "name": "REDCap Webservices url for appointment data: ",
+            "name": "REDCap Webservices url for appointment data",
             "type": "text"
         },
         {

--- a/js/populate_appointment_table.js
+++ b/js/populate_appointment_table.js
@@ -1,0 +1,69 @@
+$(document).ready(function() {
+    populateTable();
+});
+
+function populateTable() {
+    $.getJSON(FRCOVID.data_endpoint, function(data) {
+        let tbl_body = "";
+        let i = 0;
+        tbl_body += "<thead><tr>";
+
+        // dynamically set table header columns based on JSON keys
+        let header_titles = data.data[0];
+        $.each(header_titles, function(k, v) {
+            tbl_body += `<th class='text-center'>${mapHeaderNames(k)}</th>`;
+        });
+        tbl_body += "</tr></thead>";
+        tbl_body += "<tbody>";
+
+        // dynamically populate table rows
+        $.each(data.data, function() {
+            let tbl_row = "";
+            let row_color = "";
+            $.each(this, function(k , v) {
+                if (k == 'available' && v == 0) {
+                    row_color = "style='color: orange'";
+                }
+                v = mapNames(k, v);
+                tbl_row += "<td>"+v+"</td>";
+            });
+            tbl_body += `<tr ${row_color}>${tbl_row}</tr>`;
+        });
+
+        tbl_body += "</tbody>";
+        $("#appointment_table").html(tbl_body);
+    });
+}
+
+function mapHeaderNames(k) {
+    return (k in header_names_map ? header_names_map[k] : k);
+}
+
+header_names_map = {
+    'location': 'Site',
+    'testing_type': 'Test',
+    'hours': 'Hours',
+    'available': 'Avail'
+};
+
+function mapNames(k, v) {
+    switch(k) {
+        case "testing_type":
+            v = (v == 'swabandserum' ? 'Swab and Blood' :
+                    (v == 'swab' ? 'Swab' : v)
+                );
+            break;
+        case "location":
+            let site_short_name = v.match(/\(.*\)/);
+            v = ( site_short_name in location_names_map ? location_names_map[site_short_name] : v);
+            break;
+    }
+    return v;
+}
+
+location_names_map = {
+    '(KED)':  'UF Health - Kanapaha ER (KED)',
+    '(SHED)':  'UF Health - Spring Hill ER (SHED)',
+    '(UFEDSERUM)' : 'UF Health - Shands ER (UFEDSERUM)',
+    '(UFED)' : 'UF Health - Shands ER (UFED)'
+};


### PR DESCRIPTION
JS currently contains mappings for FR project, but these won't affect any information

Requires:

1. Creating a query with [RC Webservices](https://github.com/ctsit/redcap_webservices)  
    -  example queries for FR and PK Yonge below
1. Setting that URL in the Project level configuration in the option "REDCap Webservices url for appointment data"  (remember to fill in variables such as project_id in the parameters as needed)
1. Adding a descriptive text field to the REDCap survey on the appointment page with the `field_label` containing at least HTML to create a table with id `appointment_table`:  
```html
<table id="appointment_table"></table>
```

Reccomended HTML:  
```html
<table id="appointment_table" class="table table-borderless table-responsive"></table>
```

Further styling should likely be done with CSS injector.


Example SQL for REDCap Webservices:

```sql
-- FR
-- site long + short, test type, hours of operation, avail
SELECT CONCAT(site_long_name, ' (', site_short_name, ')') AS location,
    ts.testing_type,
    CONCAT(ts.open_time, ' - ', ts.close_time) AS hours,
    COUNT(IF(fra.record_id IS NULL, 1, NULL)) AS available
        FROM redcap_entity_fr_appointment AS fra
        INNER join redcap_entity_test_site AS ts ON (fra.site = ts.id)
        WHERE ts.project_id = [project-id]
        AND ( fra.appointment_block > UNIX_TIMESTAMP( DATE( NOW() + INTERVAL IF(HOUR(NOW()) >= 16, 2, 1) DAY ) ) )
        GROUP BY site

-- PKY
SELECT value AS grade, 85 - COUNT(*) AS available FROM redcap_data
    WHERE project_id = [project-id]
    AND field_name = 'icf_grade'
    GROUP BY value
    ORDER BY CAST(value AS UNSIGNED)
```