### PR TITLE
Feature/extend possible appointments

### DIFF
--- a/classes/entity/TestSite.php
+++ b/classes/entity/TestSite.php
@@ -70,7 +70,7 @@ INSERT INTO redcap_entity_fr_appointment (created, updated, site, appointment_bl
 SELECT unix_timestamp(), unix_timestamp(), $site_id, FLOOR(UNIX_TIMESTAMP(date)), $project_id
             FROM (
                 SELECT (DATE('$start_date') + INTERVAL c.number*$minute_interval MINUTE) AS date
-                    FROM (SELECT singles + tens + hundreds number FROM 
+                    FROM (SELECT singles + tens + hundreds + thousands number FROM 
                         ( SELECT 0 singles
                             UNION ALL SELECT   1 UNION ALL SELECT   2 UNION ALL SELECT   3
                             UNION ALL SELECT   4 UNION ALL SELECT   5 UNION ALL SELECT   6
@@ -85,7 +85,12 @@ SELECT unix_timestamp(), unix_timestamp(), $site_id, FLOOR(UNIX_TIMESTAMP(date))
                             UNION ALL SELECT  100 UNION ALL SELECT  200 UNION ALL SELECT  300
                             UNION ALL SELECT  400 UNION ALL SELECT  500 UNION ALL SELECT  600
                             UNION ALL SELECT  700 UNION ALL SELECT  800 UNION ALL SELECT  900
-                        ) hundreds
+                        ) hundreds JOIN
+                        (SELECT 0 thousands
+                            UNION ALL SELECT  1000 UNION ALL SELECT  2000 UNION ALL SELECT  3000
+                            UNION ALL SELECT  4000 UNION ALL SELECT  5000 UNION ALL SELECT  6000
+                            UNION ALL SELECT  7000 UNION ALL SELECT  8000 UNION ALL SELECT  9000
+                        ) thousands
                     ORDER BY number DESC) c 
                 WHERE c.number BETWEEN 0 AND $mults_needed
             ) dates

--- a/example/dynamic_sql_query_for_appointment.sql
+++ b/example/dynamic_sql_query_for_appointment.sql
@@ -53,8 +53,10 @@ SELECT a.id, CONCAT(b.site_short_name, ' - ', from_unixtime(a.appointment_block,
             ( appointment_block > UNIX_TIMESTAMP(
                      -- If it is later than 3pm, only show appointments at least 2 days from today
                     DATE( NOW() + INTERVAL IF(HOUR(NOW()) >= 15, 2, 1) DAY ) +
-                    -- if it's Saturday, add an additional day
-                    INTERVAL IF(WEEKDAY(NOW()) = 5 AND HOUR(NOW()) >= 15, 1, 0) DAY
+                    -- if it's Saturday after 3, add an additional day
+                    INTERVAL IF(WEEKDAY(NOW()) = 5 AND HOUR(NOW()) >= 15, 1, 0) DAY +
+                    -- or if it's Sunday
+                    INTERVAL IF(WEEKDAY(NOW()) = 6, 1, 0) DAY
                 )
             )
             -- unless it's an entry for the same visit for this person, and it's not a survey


### PR DESCRIPTION
Prior to this PR, there was a maximum of 999 possible appointment intervals, dependent only on the `appointment_duration`. The upshot of this is that attempting to create, for example, 5 days of appointments at a 5 minute interval (5 days * 24 hours/day *  (60 minutes/hour / 5 minutes) = 1440 5 minute blocks) you would not generate some of your expected appointments.